### PR TITLE
Allow specifying the use of Maven Central

### DIFF
--- a/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
+++ b/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
@@ -38,6 +38,7 @@ public class Concord implements TestRule {
     private boolean streamAgentLogs;
     private boolean streamServerLogs;
     private boolean useLocalMavenRepository;
+    private boolean useMavenCentral = true;
 
     private ImagePullPolicy pullPolicy;
     private Mode mode = Mode.DOCKER;
@@ -212,6 +213,18 @@ public class Concord implements TestRule {
 
     public boolean useLocalMavenRepository() {
         return this.useLocalMavenRepository;
+    }
+
+    /**
+     * If {@code true} Maven Central will be used for artifact resolution.
+     */
+    public Concord useMavenCentral(boolean useMavenCentral) {
+        this.useMavenCentral = useMavenCentral;
+        return this;
+    }
+
+    public boolean useMavenCentral() {
+        return this.useMavenCentral;
     }
 
     /**

--- a/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
+++ b/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
@@ -215,7 +215,7 @@ public class DockerConcordEnvironment implements ConcordEnvironment {
         }
 
         if ((opts.useMavenCentral() || opts.useLocalMavenRepository()) && opts.mavenConfigurationPath() != null) {
-            log.warn("Can't use 'mavenConfigurationPath' is mutually exclusive with 'useLocalMavenRepository' or 'useMavenCentral' simultaneously.");
+            log.warn("The 'mavenConfigurationPath' option is mutually exclusive with 'useLocalMavenRepository' or 'useMavenCentral'.");
         }
     }
 


### PR DESCRIPTION
By default using Maven Central will be enabled, so when you enable
useLocalMavenRepository(true), Maven Central will also be consulted.