### PR TITLE
Allow the specification of full image names

### DIFF
--- a/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
+++ b/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
@@ -51,7 +51,6 @@ public class Concord {
     private String pathToRunnerV2;
     private String serverClassesDirectory;
     private String serverExtDirectory;
-    private String version = "latest";
 
     private List<ContainerListener> containerListeners;
 
@@ -125,18 +124,6 @@ public class Concord {
      */
     public Concord mode(Mode mode) {
         this.mode = mode;
-        return this;
-    }
-
-    public String version() {
-        return version;
-    }
-
-    /**
-     * The version of Concord to be used for testing.
-     */
-    public Concord version(String version) {
-        this.version = version;
         return this;
     }
 


### PR DESCRIPTION
This allows for using entirely different server and agent images. For example,
you might want to use:

concordworkflow/concord-k8s-server:0.0.7

and

walmartlabs/concord-agent

Where an exact version for the server image is specified, and the agent defaults
to the latest version of the standard agent image.