### PR TITLE
Allow the shaded artifact to be the primary artifact

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -236,9 +236,7 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                             </transformers>
                             <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml
-                            </dependencyReducedPomLocation>
+                            <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>


### PR DESCRIPTION
This will result in a testcontainers-concord artifact the is ~20mb, but
allows the embedding in a client environment that may share many of
the same dependencies.

This more closely resembles how you would use concord in production
where it is a separate system that has little chance of conflicting
with your environment.