### PR TITLE
Allow Concord environment creation to be overridden

### DIFF
--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
@@ -22,6 +22,7 @@ package ca.ibodrov.concord.testcontainers;
 
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.client.ConcordApiClient;
+import org.jetbrains.annotations.NotNull;
 import org.testcontainers.images.ImagePullPolicy;
 import org.testcontainers.images.PullPolicy;
 
@@ -395,18 +396,36 @@ public class Concord<T extends Concord<T>> implements AutoCloseable {
     private ConcordEnvironment createEnvironment() {
         switch (mode) {
             case LOCAL: {
-                return new LocalConcordEnvironment(this);
+                return createLocalConcordEnvironment();
             }
             case DOCKER: {
-                return new DockerConcordEnvironment(this);
+                return createDockerConcordEnvironment();
             }
             case REMOTE: {
-                return new RemoteConcordEnvironment(this);
+                return createRemoteConcordEnvironment();
             }
             default: {
                 throw new IllegalArgumentException("Unsupported mode: " + mode);
             }
         }
+    }
+
+    @NotNull
+    protected RemoteConcordEnvironment createRemoteConcordEnvironment()
+    {
+        return new RemoteConcordEnvironment(this);
+    }
+
+    @NotNull
+    protected DockerConcordEnvironment createDockerConcordEnvironment()
+    {
+        return new DockerConcordEnvironment(this);
+    }
+
+    @NotNull
+    protected LocalConcordEnvironment createLocalConcordEnvironment()
+    {
+        return new LocalConcordEnvironment(this);
     }
 
     public enum Mode {

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/LocalConcordEnvironment.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/LocalConcordEnvironment.java
@@ -82,6 +82,11 @@ public class LocalConcordEnvironment implements ConcordEnvironment {
         return apiToken;
     }
 
+    public ConcordServer server()
+    {
+        return server;
+    }
+
     @Override
     public void start() {
         apiPort = Utils.reservePort(8001);

--- a/testcontainers-concord-junit4/src/main/java/ca/ibodrov/concord/testcontainers/junit4/ConcordRule.java
+++ b/testcontainers-concord-junit4/src/main/java/ca/ibodrov/concord/testcontainers/junit4/ConcordRule.java
@@ -20,29 +20,6 @@ package ca.ibodrov.concord.testcontainers.junit4;
  * =====
  */
 
-import ca.ibodrov.concord.testcontainers.Concord;
-import ca.ibodrov.concord.testcontainers.ConcordEnvironment;
-import ca.ibodrov.concord.testcontainers.ProcessLogStreamers;
-import org.junit.rules.TestRule;
-import org.junit.runner.Description;
-import org.junit.runners.model.Statement;
+public class ConcordRule extends ConcordRuleBase<ConcordRule> {
 
-public class ConcordRule extends Concord<ConcordRule> implements TestRule {
-
-    @Override
-    public Statement apply(Statement base, Description description) {
-        return new Statement() {
-            @Override
-            public void evaluate() throws Throwable {
-                try (ConcordEnvironment env = initEnvironment()) {
-                    env.start();
-                    try {
-                        base.evaluate();
-                    } finally {
-                        ProcessLogStreamers.stop();
-                    }
-                }
-            }
-        };
-    }
 }

--- a/testcontainers-concord-junit4/src/main/java/ca/ibodrov/concord/testcontainers/junit4/ConcordRuleBase.java
+++ b/testcontainers-concord-junit4/src/main/java/ca/ibodrov/concord/testcontainers/junit4/ConcordRuleBase.java
@@ -1,0 +1,49 @@
+package ca.ibodrov.concord.testcontainers.junit4;
+
+/*-
+ * *****
+ * Concord
+ * -----
+ * Copyright (C) 2020 Ivan Bodrov
+ * -----
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =====
+ */
+
+import ca.ibodrov.concord.testcontainers.Concord;
+import ca.ibodrov.concord.testcontainers.ConcordEnvironment;
+import ca.ibodrov.concord.testcontainers.ProcessLogStreamers;
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class ConcordRuleBase<T extends Concord<T>>
+        extends Concord<T> implements TestRule {
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                try (ConcordEnvironment env = initEnvironment()) {
+                    env.start();
+                    try {
+                        base.evaluate();
+                    } finally {
+                        ProcessLogStreamers.stop();
+                    }
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
Allow Concord environment creation to be overridden so that values such as the injector can be captured.