### PR TITLE
Enable push files into running containers

### DIFF
--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ContainerListener.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ContainerListener.java
@@ -20,7 +20,19 @@ package ca.ibodrov.concord.testcontainers;
  * =====
  */
 
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+
 public interface ContainerListener {
 
     void beforeStart(ContainerType type);
+
+    /**
+     * @param type
+     * @return a list of files to transfer into the container once it's running
+     */
+    default Map<Path, Path> filesToTransfer(ContainerType type) {
+        return Collections.emptyMap();
+    }
 }

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ContainerListener.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ContainerListener.java
@@ -20,20 +20,11 @@ package ca.ibodrov.concord.testcontainers;
  * =====
  */
 
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.Map;
+import org.testcontainers.containers.Container;
 
 public interface ContainerListener {
 
     void beforeStart(ContainerType type);
 
-    /**
-     * Return a map of source -> destination paths to copy to the container
-     * @param type Type of container to which the files will be copied
-     * @return map of files to transfer into the container once it's running
-     */
-    default Map<Path, Path> filesToTransfer(ContainerType type) {
-        return Collections.emptyMap();
-    }
+    void afterStart(ContainerType type, Container<?> container);
 }

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ContainerListener.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ContainerListener.java
@@ -29,8 +29,9 @@ public interface ContainerListener {
     void beforeStart(ContainerType type);
 
     /**
-     * @param type
-     * @return a list of files to transfer into the container once it's running
+     * Return a map of source -> destination paths to copy to the container
+     * @param type Type of container to which the files will be copied
+     * @return map of files to transfer into the container once it's running
      */
     default Map<Path, Path> filesToTransfer(ContainerType type) {
         return Collections.emptyMap();

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
@@ -201,9 +201,9 @@ public class DockerConcordEnvironment implements ConcordEnvironment {
 
     private void transferFiles(GenericContainer<?> c, ContainerType t) {
         this.containerListeners.forEach(l ->
-                l.filesToTransfer(t).forEach((key, value) -> {
-                    c.copyFileToContainer(MountableFile.forHostPath(key), value.toString());
-                })
+                l.filesToTransfer(t).forEach((src, dst) -> 
+                    c.copyFileToContainer(MountableFile.forHostPath(src), dst.toString())
+                )
         );
     }
 

--- a/testcontainers-concord-core/src/test/java/ca/ibodrov/concord/testcontainers/DockerTest.java
+++ b/testcontainers-concord-core/src/test/java/ca/ibodrov/concord/testcontainers/DockerTest.java
@@ -51,7 +51,9 @@ public class DockerTest {
                         // Create test file
                         try {
                             Files.createDirectories(testFile.getParent());
-                            Files.write(testFile, "Hello, Concord!".getBytes(), StandardOpenOption.CREATE);
+                            Files.write(testFile,
+                                "Hello, Concord!".getBytes(),
+                                StandardOpenOption.CREATE);
                         } catch (Exception ex) {
                             throw new RuntimeException("Failed to set up file to be copied to container");
                         }


### PR DESCRIPTION
Some CI environments may not allow bind mounting of paths (e.g. `~/.m2` for dependency resolution). This allows a workaround for such cases.