### PR TITLE
Extend ConcordProcess log access methods

### DIFF
--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ConcordProcess.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ConcordProcess.java
@@ -25,15 +25,23 @@ import com.google.gson.reflect.TypeToken;
 import com.squareup.okhttp.Call;
 import com.walmartlabs.concord.ApiClient;
 import com.walmartlabs.concord.ApiException;
+import com.walmartlabs.concord.StringUtil;
+import com.walmartlabs.concord.agent.logging.FileWatcher;
 import com.walmartlabs.concord.client.*;
 import com.walmartlabs.concord.client.ProcessEntry.StatusEnum;
+import org.apache.commons.io.IOUtils;
 import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.lang.reflect.Type;
 import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ConcordProcess {
 
@@ -210,8 +218,8 @@ public class ConcordProcess {
             throw new RuntimeException("Error converting out variables: " + e.getMessage());
         }
     }
-
-    private byte[] getLog() throws ApiException {
+    
+    public byte[] getLog() throws ApiException {
         Set<String> auths = client.getAuthentications().keySet();
         String[] authNames = auths.toArray(new String[0]);
 

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ConcordProcess.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/ConcordProcess.java
@@ -218,7 +218,24 @@ public class ConcordProcess {
             throw new RuntimeException("Error converting out variables: " + e.getMessage());
         }
     }
-    
+
+    public List<String> getLogLines() throws ApiException{
+        return getLogLines(line -> true);
+    }
+
+    public List<String> getLogLines(Predicate<String> lineFilter) throws ApiException{
+        try {
+            return IOUtils.readLines(
+                    new InputStreamReader(
+                            new ByteArrayInputStream(getLog())))
+                    .stream()
+                    .filter(lineFilter)
+                    .collect(Collectors.toList());
+        }catch (IOException ioex){
+            throw new RuntimeException("Failed to read log lines", ioex);
+        }
+    }
+
     public byte[] getLog() throws ApiException {
         Set<String> auths = client.getAuthentications().keySet();
         String[] authNames = auths.toArray(new String[0]);


### PR DESCRIPTION
Changes:
 - exposed getLog method
 - add getLogLines with and without line filter

CC: @ibodrov 