### PR TITLE
Support for dynamic agent api token

### DIFF
--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
@@ -219,6 +219,7 @@ public class DockerConcordEnvironment implements ConcordEnvironment {
         try {
             Path dst = Files.createTempFile("server", ".dst");
             String s = Resources.toString(DockerConcordEnvironment.class.getResource("docker/concord.conf"), Charsets.UTF_8);
+            s = s.replace("%%agentToken%%", Utils.randomToken());
             s = s.replace("%%persistentWorkDir%%", persistentWorkDir != null ? persistentWorkDir.toString() : "");
             s = s.replace("%%extra%%", extraConfigurationSupplier != null ? extraConfigurationSupplier.get() : "");
             Files.write(dst, s.getBytes(), StandardOpenOption.TRUNCATE_EXISTING);
@@ -261,7 +262,7 @@ public class DockerConcordEnvironment implements ConcordEnvironment {
     }
 
     private static String getApiToken(String s) {
-        String msg = "API token created: ";
+        String msg = "API token created for user 'admin': ";
         int start = s.indexOf(msg);
         if (start >= 0) {
             int end = s.indexOf('\n', start);

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/LocalConcordEnvironment.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/LocalConcordEnvironment.java
@@ -39,10 +39,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
 
 public class LocalConcordEnvironment implements ConcordEnvironment {
@@ -76,7 +74,7 @@ public class LocalConcordEnvironment implements ConcordEnvironment {
             db.dependsOn(dependsOn);
         }
 
-        this.apiToken = randomToken();
+        this.apiToken = Utils.randomToken();
 
         this.pathToRunnerV1 = opts.pathToRunnerV1();
         this.pathToRunnerV2 = opts.pathToRunnerV2();
@@ -178,14 +176,6 @@ public class LocalConcordEnvironment implements ConcordEnvironment {
         if (opts.apiToken() != null) {
             log.warn("Can't specify 'apiToken' value when using Mode.DOCKER");
         }
-    }
-
-    private static String randomToken() {
-        byte[] ab = new byte[16];
-        ThreadLocalRandom.current().nextBytes(ab);
-
-        Base64.Encoder e = Base64.getEncoder().withoutPadding();
-        return e.encodeToString(ab);
     }
 
     private static void waitForHttp(String url, long timeout) throws IOException {

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Utils.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Utils.java
@@ -33,10 +33,7 @@ import java.io.*;
 import java.net.ServerSocket;
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
 public final class Utils {
@@ -120,6 +117,14 @@ public final class Utils {
         }
 
         return b.toString();
+    }
+
+    public static String randomToken() {
+        byte[] ab = new byte[16];
+        ThreadLocalRandom.current().nextBytes(ab);
+
+        Base64.Encoder e = Base64.getEncoder().withoutPadding();
+        return e.encodeToString(ab);
     }
 
     public static String randomPwd() {

--- a/testcontainers-concord-core/src/main/resources/ca/ibodrov/concord/testcontainers/docker/concord.conf
+++ b/testcontainers-concord-core/src/main/resources/ca/ibodrov/concord/testcontainers/docker/concord.conf
@@ -2,6 +2,10 @@ concord-server {
     db {
         appPassword = "q1"
         inventoryPassword = "q1"
+
+        changeLogParameters {
+            defaultAgentToken = "%%agentToken%%"
+        }
     }
 
     secretStore {
@@ -14,6 +18,10 @@ concord-server {
 concord-agent {
     runner {
         persistentWorkDir = "%%persistentWorkDir%%"
+    }
+
+    server {
+        apiKey = "%%agentToken%%"
     }
 }
 


### PR DESCRIPTION
Supports changes in https://github.com/walmartlabs/concord/pull/410

After that's release, this repo will need to update the `LocalConcordEnvironment` to handle the agent token and bump the server version appropriately.