### PR TITLE
Project API compat with 2.25.0, docker image env var override

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ public class MyTest {
 By default, the DB, the Server and the Agent are started using Docker containers.
 See below for other options.
 
+Server and Agent container image versions can be customized programmatically, or
+overridden using environment variables (handy for testing against alternative
+versions or custom images.
+
+```
+export TESTCONTAINERS_CONCORD_DB_IMAGE=myregistry/library/postgres:10
+export TESTCONTAINERS_CONCORD_SERVER_IMAGE=myregistry/altowner/concord-server:custom-tag
+export TESTCONTAINERS_CONCORD_AGENT_IMAGE=myregistry/myowner/concord-agent:custom-tag
+$ ./mvnw clean install
+```
+
 See [test cases](./src/test/java/ca/ibodrov/concord/testcontainers/RuleTest.java) for
 details.
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/testcontainers-concord-core/pom.xml
+++ b/testcontainers-concord-core/pom.xml
@@ -104,7 +104,6 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Concord.java
@@ -34,6 +34,10 @@ import java.util.function.Supplier;
 @SuppressWarnings({"unchecked"})
 public class Concord<T extends Concord<T>> implements AutoCloseable {
 
+    private static final String TESTCONTAINERS_CONCORD_DB_IMAGE = "TESTCONTAINERS_CONCORD_DB_IMAGE";
+    private static final String TESTCONTAINERS_CONCORD_SERVER_IMAGE = "TESTCONTAINERS_CONCORD_SERVER_IMAGE";
+    private static final String TESTCONTAINERS_CONCORD_AGENT_IMAGE = "TESTCONTAINERS_CONCORD_AGENT_IMAGE";
+
     private boolean startAgent = true;
     private boolean streamAgentLogs;
     private boolean streamServerLogs;
@@ -173,7 +177,7 @@ public class Concord<T extends Concord<T>> implements AutoCloseable {
     }
 
     public String dbImage() {
-        return dbImage;
+        return Utils.getEnv(TESTCONTAINERS_CONCORD_DB_IMAGE, dbImage);
     }
 
     public T dbImage(String dbImage) {
@@ -182,7 +186,7 @@ public class Concord<T extends Concord<T>> implements AutoCloseable {
     }
 
     public String serverImage() {
-        return serverImage;
+        return Utils.getEnv(TESTCONTAINERS_CONCORD_SERVER_IMAGE, serverImage);
     }
 
     /**
@@ -194,7 +198,7 @@ public class Concord<T extends Concord<T>> implements AutoCloseable {
     }
 
     public String agentImage() {
-        return agentImage;
+        return Utils.getEnv(TESTCONTAINERS_CONCORD_AGENT_IMAGE, agentImage);
     }
 
     /**

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/DockerConcordEnvironment.java
@@ -21,7 +21,6 @@ package ca.ibodrov.concord.testcontainers;
  */
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
 import com.walmartlabs.concord.common.Posix;
 import org.slf4j.Logger;
@@ -39,9 +38,9 @@ import org.testcontainers.lifecycle.Startable;
 import org.testcontainers.utility.MountableFile;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.*;
@@ -226,7 +225,7 @@ public class DockerConcordEnvironment implements ConcordEnvironment {
     private static Path prepareConfigurationFile(Path persistentWorkDir, Supplier<String> extraConfigurationSupplier) {
         try {
             Path dst = Files.createTempFile("server", ".dst");
-            String s = Resources.toString(DockerConcordEnvironment.class.getResource("docker/concord.conf"), Charsets.UTF_8);
+            String s = Resources.toString(DockerConcordEnvironment.class.getResource("docker/concord.conf"), StandardCharsets.UTF_8);
             s = s.replace("%%agentToken%%", Utils.randomToken());
             s = s.replace("%%persistentWorkDir%%", persistentWorkDir != null ? persistentWorkDir.toString() : "");
             s = s.replace("%%extra%%", extraConfigurationSupplier != null ? extraConfigurationSupplier.get() : "");
@@ -251,7 +250,7 @@ public class DockerConcordEnvironment implements ConcordEnvironment {
         this.containerListeners.forEach(l -> l.afterStart(type, container));
     }
 
-    private static ImagePullPolicy pullPolicy(Concord opts) {
+    private static ImagePullPolicy pullPolicy(Concord<?> opts) {
         ImagePullPolicy p = opts.pullPolicy();
 
         if (p == null) {

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/LocalConcordEnvironment.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/LocalConcordEnvironment.java
@@ -33,10 +33,7 @@ import org.testcontainers.lifecycle.Startable;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.net.URL;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -114,7 +111,7 @@ public class LocalConcordEnvironment implements ConcordEnvironment {
             Path conf = prepareConfigurationFile();
             System.setProperty("ollie.conf", conf.toAbsolutePath().toString());
 
-            this.server = ConcordServer.withAutoWiring().start();
+            this.server = ConcordServer.withModules().start();
 
             waitForHttp("http://localhost:" + apiPort() + "/api/v1/server/ping", 60000);
         } catch (Exception e) {

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Projects.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Projects.java
@@ -31,26 +31,13 @@ public class Projects {
     }
 
     public ProjectOperationResponse create(String orgName, String projectName) throws ApiException {
-        return create(orgName, projectName, true); // true to maintain backward compatibility
-    }
-
-    public ProjectOperationResponse create(String orgName, String projectName, boolean allowPayloads) throws ApiException {
         ProjectEntry projectEntry = new ProjectEntry()
                 .name(projectName)
                 .orgName(orgName)
                 .acceptsRawPayload(Boolean.TRUE)
-                .rawPayloadMode(ProjectEntry.RawPayloadModeEnum.TEAM_MEMBERS)
+                .rawPayloadMode(ProjectEntry.RawPayloadModeEnum.EVERYONE)
                 .visibility(ProjectEntry.VisibilityEnum.PUBLIC);
 
-        var project = projectApi.createOrUpdateProject(orgName, projectEntry);
-
-        if (allowPayloads) {
-            projectApi.updateProjectAccessLevel(orgName, projectName, new ResourceAccessEntry()
-                    .orgName(orgName)
-                    .teamName("default")
-                    .level(ResourceAccessEntry.LevelEnum.OWNER));
-        }
-
-        return project;
+        return projectApi.createOrUpdateProject(orgName, projectEntry);
     }
 }

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Projects.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Projects.java
@@ -31,12 +31,26 @@ public class Projects {
     }
 
     public ProjectOperationResponse create(String orgName, String projectName) throws ApiException {
+        return create(orgName, projectName, true); // true to maintain backward compatibility
+    }
+
+    public ProjectOperationResponse create(String orgName, String projectName, boolean allowPayloads) throws ApiException {
         ProjectEntry projectEntry = new ProjectEntry()
                 .name(projectName)
                 .orgName(orgName)
                 .acceptsRawPayload(Boolean.TRUE)
+                .rawPayloadMode(ProjectEntry.RawPayloadModeEnum.TEAM_MEMBERS)
                 .visibility(ProjectEntry.VisibilityEnum.PUBLIC);
 
-        return projectApi.createOrUpdateProject(orgName, projectEntry);
+        var project = projectApi.createOrUpdateProject(orgName, projectEntry);
+
+        if (allowPayloads) {
+            projectApi.updateProjectAccessLevel(orgName, projectName, new ResourceAccessEntry()
+                    .orgName(orgName)
+                    .teamName("default")
+                    .level(ResourceAccessEntry.LevelEnum.OWNER));
+        }
+
+        return project;
     }
 }

--- a/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Utils.java
+++ b/testcontainers-concord-core/src/main/java/ca/ibodrov/concord/testcontainers/Utils.java
@@ -122,6 +122,16 @@ public final class Utils {
         return Paths.get(localPath);
     }
 
+    public static String getEnv(String name, String defValue) {
+        String envValue = System.getenv(name);
+
+        if (envValue == null || envValue.isBlank()) {
+            return defValue;
+        } else {
+            return envValue;
+        }
+    }
+
     private Utils() {
     }
 }

--- a/testcontainers-concord-core/src/test/java/ca/ibodrov/concord/testcontainers/DockerTest.java
+++ b/testcontainers-concord-core/src/test/java/ca/ibodrov/concord/testcontainers/DockerTest.java
@@ -42,8 +42,6 @@ import org.junit.jupiter.api.Test;
 import static ca.ibodrov.concord.testcontainers.Utils.randomString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DockerTest {
 
@@ -115,30 +113,6 @@ class DockerTest {
         concord.projects().create(orgName, projectName);
 
         executeSimpleFlow(payload -> payload.org(orgName).project(projectName));
-    }
-
-    @Test
-    void testSimpleFlowWithProjectAndExplicitPayloadSetting() throws Exception {
-        String orgName = "org_" + randomString();
-        concord.organizations().create(orgName);
-
-        String projectName = "project_" + randomString();
-        concord.projects().create(orgName, projectName, true);
-
-        executeSimpleFlow(payload -> payload.org(orgName).project(projectName));
-    }
-
-    @Test
-    void testPayloadInProjectWithoutEnablingPayloads() throws Exception {
-        String orgName = "org_" + randomString();
-        concord.organizations().create(orgName);
-
-        String projectName = "project_" + randomString();
-        concord.projects().create(orgName, projectName, false);
-
-        var ex = assertThrows(Exception.class, () -> executeSimpleFlow(payload -> payload.org(orgName).project(projectName)));
-        assertTrue(ex.getMessage().contains("The project is not accepting raw payloads"),
-                "Expected error for not accepting raw payloads");
     }
 
     private void executeSimpleFlow(Consumer<Payload> payloadConsumer) throws Exception {

--- a/testcontainers-concord-junit5/pom.xml
+++ b/testcontainers-concord-junit5/pom.xml
@@ -28,5 +28,11 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/testcontainers-concord-shaded/pom.xml
+++ b/testcontainers-concord-shaded/pom.xml
@@ -27,6 +27,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
There were some changes to the Project API with regard to allowing raw payloads which broke this project. This fixes them for testing with `2.25.0` and newer Concord instances, and keeps backwards compatibility for projects testing against older versions.

- Fix project creation
- Add environment variables for overriding docker images
- JDK17 maven settings



